### PR TITLE
Add commit-msg hook to strip AI co-author tags

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,21 @@
+#!/usr/bin/env -S deno run --allow-read --allow-write
+
+const commitMsgFile = Deno.args[0];
+if (!commitMsgFile) {
+  Deno.exit(0);
+}
+
+// Read the commit message
+const content = await Deno.readTextFile(commitMsgFile);
+
+// Regular expression to catch AI co-author and generated-by tags
+const filterRegex = /^(Co-Authored-By:.*(Claude|Anthropic|GitHub Copilot|ChatGPT|openai)|(Generated|Assisted)[- ]by:.*(Claude|Anthropic|AI)).*$/gim;
+
+// Strip matching lines and cleanup trailing empty lines
+const cleaned = content
+  .replace(filterRegex, "")
+  .replace(/\n{3,}/g, "\n\n")
+  .trimEnd() + "\n";
+
+// Write the modified message back
+await Deno.writeTextFile(commitMsgFile, cleaned);

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,4 @@
+# Git Guidelines
+
+- Do not add 'Co-Authored-By', generator tags, or any AI references to commit messages or PR descriptions.
+- Keep commit messages concise and strictly focused on changes.


### PR DESCRIPTION
Adds a commit-msg hook that removes Co-Authored-By/Generated-by lines referencing AI tools, plus .gitattributes for consistent line endings and CLAUDE.md documenting git guidelines.